### PR TITLE
Compatibility updates, ability to centre text vertically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ out
 .idea/**
 *.iml
 .iml
+/target/
+/install.bat
+/bin/
+/.settings/
+/.classpath
+/.project

--- a/README.md
+++ b/README.md
@@ -8,8 +8,45 @@ The image can be saved in several formats (png,jpg etc.). Fonts, styles and colo
 chosen for the text being rendered. See the src/test/nl/jamiecraane/imagegenerator/examples 
 packages for numerous examples of how to use this library.
 
-For an actual example see my blogpost about this project at http://jcraane.blogspot.com/2009/01/text-image-generator-example.html
+For there's an actual example in my blogpost about this project at http://jcraane.blogspot.com/2009/01/text-image-generator-example.html, but it's a bit outdated. The following is a working example that uses this library to create an image with some text in it:
 
-To use this library just add downloaded jar file to your projects classpath.
+```
+TextImage textImage = new TextImageImpl(400, 250, new Margin(0, 0));
+
+// Declare or read the fonts you need
+Font header = new Font("Sans-Serif", Font.BOLD, 15);
+Font plain = new Font("Sans-Serif", Font.PLAIN, 12);
+
+// Read in any images you need
+InputStream is = Main.class.getResourceAsStream("/Warning2.png");
+Image warning = ImageIO.read(is);
+// Put close() in try-finally block with production code! 
+is.close();
+
+// 1. specify font and write text with a newline
+textImage.withFont(header).writeLine("Example usage text-image-generator.").newLine();
+// 2. enabled the wrapping of text and write text which is automatically wrapped 
+textImage.withFont(plain).wrap(true).write("This is an example of how to use the text-image generation library. With this library you can dynamically generated textbased content as images (png or jpeg). Notice how this sentence is automatically wrapped. See the code at http://code.google.com/p/textimagegenerator/ for more examples.").newLine();
+
+// 3. Disable text-wrapping again. Write underlined text.
+textImage.wrap(false).withColor(Color.BLUE).withFontStyle(Style.UNDERLINED).write("This line of text is underlinedand blue.").withFontStyle(Style.PLAIN).newLine();
+textImage.writeLine("You can also embed images in your generated image:");
+// 4. embed the actual image. Here we use absolute positioning
+textImage.write(warning, 175, 175);
+
+// 5. Write the image as a png to a file
+OutputStream os = new FileOutputStream(new File(PATH, "example.png"));
+ImageWriter imageWriter = ImageWriterFactory.getImageWriter(ImageType.PNG);
+imageWriter.writeImageToOutputStream(textImage, os);
+os.close();
+```
+
+To use this library just add the downloaded jar file to your projects classpath.
+You can also clone the whole repository to your computer and use Maven to package and install it into your local repository, like this:
+
+```
+mvn install
+```
+
 This project has minimal dependencies on external libraries (see pom.xml). The distributable can be found under downloads. 
-This jar is compatible with Java 5 or higher. A 1.4 compatible version is planned.
+This jar is compatible with Java 1.8 or higher.

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/capaxit/imagegenerator/TextImage.java
+++ b/src/main/java/org/capaxit/imagegenerator/TextImage.java
@@ -54,6 +54,7 @@ public interface TextImage {
 	 * @return this
 	 */
 	TextImage addVSpace(int space);
+	
 	/**
 	 * Enables/disables the wrapping of text at the right end margin when the
 	 * methods are used with no explicit newline, like {@link #write(String)}.
@@ -63,6 +64,15 @@ public interface TextImage {
      * @return this
 	 */
 	TextImage wrap(boolean enable);
+	
+	/**
+	 * Enables/disables vertically centred text.
+	 * @param enable
+	 *            true enables vertically centred text, false disables
+	 *            vertically centred text.
+	 * @return this
+	 */
+	TextImage verticallyCentreText(boolean enable);
 
 	/**
 	 * @return The height of the image in pixels.

--- a/src/main/java/org/capaxit/imagegenerator/impl/TextImageImpl.java
+++ b/src/main/java/org/capaxit/imagegenerator/impl/TextImageImpl.java
@@ -16,15 +16,30 @@
 
 package org.capaxit.imagegenerator.impl;
 
-import org.capaxit.imagegenerator.*;
-import org.capaxit.imagegenerator.textalign.*;
-import org.capaxit.imagegenerator.util.Validate;
-
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.capaxit.imagegenerator.Align;
+import org.capaxit.imagegenerator.Alignment;
+import org.capaxit.imagegenerator.DrawableText;
+import org.capaxit.imagegenerator.Margin;
+import org.capaxit.imagegenerator.Style;
+import org.capaxit.imagegenerator.TextImage;
+import org.capaxit.imagegenerator.TextImageCallback;
+import org.capaxit.imagegenerator.TextWrapper;
+import org.capaxit.imagegenerator.textalign.Center;
+import org.capaxit.imagegenerator.textalign.GreedyTextWrapper;
+import org.capaxit.imagegenerator.textalign.Justify;
+import org.capaxit.imagegenerator.textalign.LeftAlign;
+import org.capaxit.imagegenerator.textalign.RightAlign;
+import org.capaxit.imagegenerator.util.Validate;
 
 /**
  * Implementation of the {@link org.capaxit.imagegenerator.TextImage} interface. The default font is
@@ -38,9 +53,6 @@ import java.util.Map;
  * This class is NOT threadsafe.
  */
 public final class TextImageImpl implements TextImage {
-    private static final String JPEG = "jpeg";
-    private static final int MAX_COMPRESSION = 1;
-    private static final String PNG = "png";
     private final int width;
 
     private final int height;
@@ -56,6 +68,8 @@ public final class TextImageImpl implements TextImage {
     private Margin margin = new Margin(0, 0, 0, 0);
 
     private boolean wrap = false;
+    
+    private boolean verticallyCentreText = false;
 
     private TextWrapper wrapper = new GreedyTextWrapper();
 
@@ -146,28 +160,53 @@ public final class TextImageImpl implements TextImage {
         this.wrap = enable;
         return this;
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+	@Override
+	public TextImage verticallyCentreText(boolean enable) {
+		this.verticallyCentreText = enable;
+		return this;
+	}
 
     /**
      * {@inheritDoc}
      */
     public TextImage write(final String text) {
         Validate.notNull(text, "The text may not be null.");
-
+        
         FontMetrics fm = getFontMetrics();
         if (this.wrap) {
             int lineWidth = this.width - this.margin.getLeft() - this.margin.getRight();
             List<String> lines = this.wrapper.doWrap(text, lineWidth, fm);
+            if (this.verticallyCentreText) {
+            	this.doCentreTextVertically(lines.size());
+            }
             for (String line : lines) {
                 this.writeText(fm, line);
                 this.applyStyle(fm, line);
                 this.newLine();
             }
         } else {
+        	if (this.verticallyCentreText) {
+            	this.doCentreTextVertically(1);
+            }
             this.writeText(fm, text);
             this.applyStyle(fm, text);
         }
 
         return this;
+    }
+    
+    private int getLinesHeight(int numberOfLines) {
+    	return numberOfLines * getFontMetrics().getHeight();
+    }
+    
+    private void doCentreTextVertically(int numberOfLines) {
+    	int textHeight = getLinesHeight(numberOfLines);
+    	int freeHeight = this.height - textHeight;
+    	this.addVSpace(freeHeight / 2);
     }
 
     private void applyStyle(final FontMetrics fm, final String line) {


### PR DESCRIPTION
1. As Java 1.5 compatibility is no longer allowed, I've updated the POM to Java 1.8.
2. I've added the ability to centre text vertically.
3. I've updated the documentation in the README.md.